### PR TITLE
Change hostname option to -H

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ php with php-curl module
 
 ## Example:
 a check command example:
-```./check_shelly -h=<shelly-ip> -u=shellyuser -p=shellypassword -w=90 -c=95```
+```./check_shelly -H <shelly-ip> -u shellyuser -p shellypassword -w 90 -c 95```
 
 ## Parameters:
-  - -h (host) is mandatory
+  - -H (host) is mandatory
   - -u (username) and -p (password) are optional, if the Shelly is protected via username / password
   - -w and -c are optional warning /critical thresholds .. (default is 90 for warning, 95 for critical)
 

--- a/check_shelly
+++ b/check_shelly
@@ -10,20 +10,20 @@ class ShellyDevice {
 	public function __construct() {
 
 		// define options for cli call
-		$options = getopt("h:u::p::w::c::H::", array("host:", "user::", "password::","warning::", "critical::" , "help"));
+		$options = getopt("H:u::p::w::c::h", array("host:", "user::", "password::","warning::", "critical::" , "help"));
 
-		// If help or the shortcut H is set print the help message
-		if(isset($options['help']) || isset($options['H'])) {
+		// If help or the shortcut h is set print the help message
+		if(isset($options['help']) || isset($options['h'])) {
 			echo "check_shelly is a nagios compatible check to monitor the health of shelly hardware.\n\n";
 			echo "You can run it for example with:\n";
-			echo "./check_shelly -h <SHELLY_IP>\n\n";
+			echo "./check_shelly -H <SHELLY_IP>\n\n";
 			echo "If you have authentication enabled then you have to run:\n";
-			echo "./check_shelly -h <SHELLY_IP> -u <USER> -p <PASSWORD>\n\n";
+			echo "./check_shelly -H <SHELLY_IP> -u <USER> -p <PASSWORD>\n\n";
 			echo "To change the warning or the critical value you can pass in -w or -c to change it\n";
-			echo "./check_shelly -h <SHELLY_IP> -w <WARNING> -c <CRITICAL>\n";
+			echo "./check_shelly -H <SHELLY_IP> -w <WARNING> -c <CRITICAL>\n";
 			echo "\n\nThe critical or warning threshold refers to the cpu usage OR the filesystem usage.";
 			echo "Available flags:\n";
-			echo "\t--host\t\t-h\t(required flag) The hostname or IP-Adress of the shelly\n";
+			echo "\t--host\t\t-H\t(required flag) The hostname or IP-Adress of the shelly\n";
 			echo "\t--user\t\t-u\tThe username for the Shelly, when the shelly needs authentication\n";
 			echo "\t--password\t-p\tThe password for the Shelly, when the shelly needs authentication\n";
 			echo "\t--warning\t-w\tThe warning threshold. If the shelly has more RAM or disk usage then  the check is warning\n";
@@ -32,11 +32,11 @@ class ShellyDevice {
 			exit(0);
 		}
 		// If no host is set print an error
-		if(!isset($options['host']) && !isset($options['h'])) {
-			echo "parameter -h || --host is missing \n";
+		if(!isset($options['host']) && !isset($options['H'])) {
+			echo "parameter -H || --host is missing \n";
 			exit(3);
 		}
-		$host =  isset($options['host']) ? $options['host'] : $options['h'];
+		$host =  isset($options['host']) ? $options['host'] : $options['H'];
 		$user =  isset($options['user']) ? $options['user'] : (isset($options['u']) ? $options['u'] : false);
 		$password =  isset($options['password']) ? $options['password'] : (isset($options['p']) ? $options['p'] : false);
 		


### PR DESCRIPTION
The [Monitoring Plugins Development Guidelines](https://www.monitoring-plugins.org/doc/guidelines.html#PLUGOPTIONS) say that the hostname should be provided with the -H option, and -h is for help. This pull request changes check_shelly to comply with this, which also makes it work better with applications that assume -H is host, such as LibreNMS.
Thanks for the plugin, it's working great with my 1Ls and Dimmer 2s!